### PR TITLE
GitHub workflow for tagging and releasing #minor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,15 @@ jobs:
         rustup update stable
         rustup target add wasm32-unknown-unknown --toolchain nightly
 
+    - name: clone 
+      run: |
+        pushd ..
+        git clone https://github.com/paritytech/substrate.git
+        cd substrate
+        git checkout monthly-2021-08
+        cd ..
+        popd
+
     - name: Build
       run: cargo build --verbose --release
   # - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 # Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
-  # push:
-  #   branches: [ master ]
+  push:
+    branches: [ github-actions ]
   # pull_request:
   #   branches: [ master ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,15 @@
 name: Release
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ github-actions ]
-  # pull_request:
-  #   branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  repository_dispatch:
+    types: [tag-created]
 
 env:
   CARGO_TERM_COLOR: always
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          # - os: macos-latest
-          #   target: x86_64-apple-darwin
-          #   suffix: ''
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            suffix: ''
-          # - os: windows-latest
-          #   target: x86_64-pc-windows-msvc
-          #   suffix: .exe
+  release:
+    name: Build and release linux-amd64
     runs-on: ubuntu-latest
 
     steps:
@@ -57,41 +38,13 @@ jobs:
 
     - name: Build
       run: cargo build --verbose --release
-  # - name: Run tests
-  #     run: cargo test --verbose
 
-
-    - uses: actions/upload-artifact@master
+    - name: Upload binary to release
+      uses: svenstaro/upload-release-action@v1-release
       with:
-        name: wika-node-${{ matrix.target }}
-        path: ./target/release/wika-node
-        # name: ${{ steps.get_repository_name.outputs.REPOSITORY_NAME }}-${{ matrix.target }}
-        # path: ./target/release/${{ steps.get_repository_name.outputs.REPOSITORY_NAME }}${{ matrix.suffix }}
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/wika-node
+        asset_name: wika-linux-amd64
+        tag: ${{ github.event.client_payload.new_version }}
 
-  # check:
-  #   # The type of runner that the job will run on
-  #   runs-on: ubuntu-20.04
-
-  #   # Steps represent a sequence of tasks that will be executed as part of the job
-  #   steps:
-  #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-  #     - uses: actions/checkout@v2
-
-  #     - name: Set-Up
-  #       run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
-
-  #     - name: Install Rustup
-  #       run: |
-  #         curl https://sh.rustup.rs -sSf | sh -s -- -y
-  #         source ~/.cargo/env
-  #         rustup default stable
-  #         rustup update nightly
-  #         rustup update stable
-  #         rustup target add wasm32-unknown-unknown --toolchain nightly
-  #     - name: Check Build
-  #       run: |
-  #         SKIP_WASM_BUILD=1 cargo check --release
-  #     - name: Check Build for Benchmarking
-  #       run: >
-  #         pushd node &&
-  #         cargo check --features=runtime-benchmarks --release
+  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  # push:
+  #   branches: [ master ]
+  # pull_request:
+  #   branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          # - os: macos-latest
+          #   target: x86_64-apple-darwin
+          #   suffix: ''
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            suffix: ''
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   suffix: .exe
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set-Up
+      run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
+
+    - name: Install Rustup
+      run: |
+        curl https://sh.rustup.rs -sSf | sh -s -- -y
+        source ~/.cargo/env
+        rustup default stable
+        rustup update nightly
+        rustup update stable
+        rustup target add wasm32-unknown-unknown --toolchain nightly
+
+    - name: Build
+      run: cargo build --verbose --release
+  # - name: Run tests
+  #     run: cargo test --verbose
+
+
+    - uses: actions/upload-artifact@master
+      with:
+        name: wika-node-${{ matrix.target }}
+        path: ./target/release/wika-node
+        # name: ${{ steps.get_repository_name.outputs.REPOSITORY_NAME }}-${{ matrix.target }}
+        # path: ./target/release/${{ steps.get_repository_name.outputs.REPOSITORY_NAME }}${{ matrix.suffix }}
+
+  # check:
+  #   # The type of runner that the job will run on
+  #   runs-on: ubuntu-20.04
+
+  #   # Steps represent a sequence of tasks that will be executed as part of the job
+  #   steps:
+  #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+  #     - uses: actions/checkout@v2
+
+  #     - name: Set-Up
+  #       run: sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
+
+  #     - name: Install Rustup
+  #       run: |
+  #         curl https://sh.rustup.rs -sSf | sh -s -- -y
+  #         source ~/.cargo/env
+  #         rustup default stable
+  #         rustup update nightly
+  #         rustup update stable
+  #         rustup target add wasm32-unknown-unknown --toolchain nightly
+  #     - name: Check Build
+  #       run: |
+  #         SKIP_WASM_BUILD=1 cargo check --release
+  #     - name: Check Build for Benchmarking
+  #       run: >
+  #         pushd node &&
+  #         cargo check --features=runtime-benchmarks --release

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -2,7 +2,7 @@ name: Bump version, create new tag and release point
 on:
   push:
     branches:
-      - github-actions
+      - master
 
 jobs:
   bump_version:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,33 @@
+name: Bump version, create new tag and release point
+on:
+  push:
+    branches:
+      - github-actions
+
+jobs:
+  bump_version:
+    name: Bump version, create tag/release point
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      # for manual bumping check https://github.com/anothrNick/github-tag-action#bumping
+      # Manual Bumping: Any commit message that includes #major, #minor, #patch, or #none 
+      # will trigger the respective version bump. 
+      # If two or more are present, the highest-ranking one will take precedence. 
+      # If #none is contained in the commit message, it will skip bumping regardless DEFAULT_BUMP.
+      - name: Bump version and push tag/create release point
+        id: bump_version
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+      - name: Repository dispatch tag created event
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          event-type: tag-created
+          client-payload: '{"new_version": "${{ steps.bump_version.outputs.new_tag }}"}'


### PR DESCRIPTION
Tagging:
on merge to master (sea tag.yml)
1.  bump version and tag:
```
from  https://github.com/anothrNick/github-tag-action#bumping
Manual Bumping: Any commit message that includes #major, #minor, #patch, or #none 
will trigger the respective version bump. 
If two or more are present, the highest-ranking one will take precedence. 
If #none is contained in the commit message, it will skip bumping regardless DEFAULT_BUMP.
```
2. dispatch event tag-created

On event tag-created:
- build and release (linux) (see release.yml)